### PR TITLE
NormalizationFunction move RawDataFilePlaceholder out of function

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/AbundanceMeasure.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/AbundanceMeasure.java
@@ -103,6 +103,12 @@ public enum AbundanceMeasure implements UniqueIdSupplier {
    */
   public float getOrNaN(@Nullable ModularDataModel featureOrRow,
       @Nullable NormalizationFunction normalizationFunction) {
+    if (isNormalized()) {
+      throw new IllegalStateException("""
+          Cannot apply normalization on already normalized values. The idea is to have composite \
+          normalization functions that apply multiply steps to the raw area or height values.""");
+    }
+
     if (featureOrRow == null) {
       return Float.NaN;
     }
@@ -116,6 +122,14 @@ public enum AbundanceMeasure implements UniqueIdSupplier {
     final Float rt = featureOrRow.get(RTType.class);
     final Double mz = featureOrRow.get(MZType.class);
     return (float) (value * normalizationFunction.getNormalizationFactor(mz, rt));
+  }
+
+
+  /**
+   * @return true if normalized
+   */
+  public boolean isNormalized() {
+    return this == NORMALIZED_AREA || this == NORMALIZED_HEIGHT;
   }
 
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/AbundanceMeasure.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/AbundanceMeasure.java
@@ -34,6 +34,7 @@ import io.github.mzmine.datamodel.features.types.numbers.NormalizedHeightType;
 import io.github.mzmine.datamodel.features.types.numbers.RTType;
 import io.github.mzmine.datamodel.utils.UniqueIdSupplier;
 import io.github.mzmine.modules.dataprocessing.norm_intensity.NormalizationFunction;
+import io.github.mzmine.modules.dataprocessing.norm_intensity.RawFileNormalizationFunction;
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -87,6 +88,20 @@ public enum AbundanceMeasure implements UniqueIdSupplier {
    * null or not a finite number
    */
   public float getOrNaN(@Nullable ModularDataModel featureOrRow,
+      @Nullable RawFileNormalizationFunction normalizationFunction) {
+    return getOrNaN(featureOrRow,
+        normalizationFunction == null ? null : normalizationFunction.function());
+  }
+
+  /**
+   * Applies a normalization function to the value
+   *
+   * @param featureOrRow          the model
+   * @param normalizationFunction a function
+   * @return the normalized value or raw value if function is null or NaN if feature or value is
+   * null or not a finite number
+   */
+  public float getOrNaN(@Nullable ModularDataModel featureOrRow,
       @Nullable NormalizationFunction normalizationFunction) {
     if (featureOrRow == null) {
       return Float.NaN;
@@ -100,7 +115,7 @@ public enum AbundanceMeasure implements UniqueIdSupplier {
     }
     final Float rt = featureOrRow.get(RTType.class);
     final Double mz = featureOrRow.get(MZType.class);
-    return (float)(value * normalizationFunction.getNormalizationFactor(mz, rt));
+    return (float) (value * normalizationFunction.getNormalizationFactor(mz, rt));
   }
 
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/AbstractFactorNormalizationTypeModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/AbstractFactorNormalizationTypeModule.java
@@ -28,10 +28,8 @@ import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
-import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTableUtils;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.util.MathUtils;
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,11 +81,9 @@ public abstract class AbstractFactorNormalizationTypeModule extends
     final Map<@NotNull RawDataFile, @NotNull NormalizationFunction> functions = new HashMap<>();
     for (final Entry<@NotNull RawDataFile, @NotNull Double> entry : referenceToNormalizationMetric.entrySet()) {
       final RawDataFile file = entry.getKey();
-      final LocalDateTime runDate = MetadataTableUtils.getRunDate(metadata, file);
       final double normalizationFactor = medianNormMetric / entry.getValue();
 
-      final NormalizationFunction function = new FactorNormalizationFunction(file, runDate,
-          normalizationFactor);
+      final NormalizationFunction function = new FactorNormalizationFunction(normalizationFactor);
       // add or merge function into a new instance within summary
       summary.addMergeFunction(file, function);
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/CompositeNormalizationFunction.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/CompositeNormalizationFunction.java
@@ -25,17 +25,10 @@
 
 package io.github.mzmine.modules.dataprocessing.norm_intensity;
 
-import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilePlaceholder;
 import io.github.mzmine.util.XMLUtils;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  *
@@ -46,24 +39,6 @@ public record CompositeNormalizationFunction(
     @NotNull List<@NotNull NormalizationFunction> functions) implements NormalizationFunction {
 
   public static final String XML_TYPE = "composite_list_normalization";
-
-  public CompositeNormalizationFunction {
-    if (functions.stream().map(NormalizationFunction::rawDataFilePlaceholder).distinct().count()
-        > 1) {
-      throw new IllegalArgumentException(
-          "CompositeListNormalizationFunction requires sub functions for the same raw data files");
-    }
-  }
-
-  @Override
-  public @NotNull RawDataFilePlaceholder rawDataFilePlaceholder() {
-    return functions.getFirst().rawDataFilePlaceholder();
-  }
-
-  @Override
-  public @Nullable LocalDateTime acquisitionTimestamp() {
-    return functions.getFirst().acquisitionTimestamp();
-  }
 
   @Override
   public double getNormalizationFactor(@NotNull Double mz, @NotNull Float rt) {
@@ -96,25 +71,12 @@ public record CompositeNormalizationFunction(
   public static @NotNull CompositeNormalizationFunction loadFromXML(
       final @NotNull Element functionElement) {
 
-    final ArrayList<NormalizationFunction> functions = new ArrayList<>();
-
     final Element subfunctions = XMLUtils.findChildElement(functionElement, "subfunctions");
 
-    final NodeList matchingNodes = subfunctions.getElementsByTagName(XML_FUNCTION_ELEMENT);
-    for (int i = 0; i < matchingNodes.getLength(); i++) {
-      final Node node = matchingNodes.item(i);
-      if (node instanceof final Element subFunElement) {
-        final NormalizationFunction subfun = NormalizationFunction.loadFromXML(subFunElement);
-        functions.add(subfun);
-      }
-    }
+    final List<@NotNull NormalizationFunction> functions = XMLUtils.streamChildElementsByTagName(
+        subfunctions, XML_FUNCTION_ELEMENT).map(NormalizationFunction::loadFromXML).toList();
 
-    return new CompositeNormalizationFunction(List.copyOf(functions));
+    return new CompositeNormalizationFunction(functions);
   }
 
-  @Override
-  public @NotNull NormalizationFunction withRawFile(@NotNull RawDataFile file) {
-    return new CompositeNormalizationFunction(
-        functions.stream().map(f -> f.withRawFile(file)).toList());
-  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/FactorNormalizationFunction.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/FactorNormalizationFunction.java
@@ -24,50 +24,17 @@
 
 package io.github.mzmine.modules.dataprocessing.norm_intensity;
 
-import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTableUtils;
-import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilePlaceholder;
 import io.github.mzmine.util.XMLUtils;
-import java.time.LocalDateTime;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Element;
 
 /**
  * Factor normalization function represented by one global factor.
  */
-public record FactorNormalizationFunction(@NotNull RawDataFilePlaceholder rawDataFilePlaceholder,
-                                          @Nullable LocalDateTime acquisitionTimestamp,
-                                          double factor) implements NormalizationFunction {
+public record FactorNormalizationFunction(double factor) implements NormalizationFunction {
 
   public static final String XML_TYPE = "factor";
   private static final String XML_FACTOR_ATTR = "factor";
-
-  public FactorNormalizationFunction(@NotNull final RawDataFile referenceFile,
-      @Nullable final LocalDateTime acquisitionTimestamp, final double factor) {
-    this(new RawDataFilePlaceholder(referenceFile), acquisitionTimestamp, factor);
-  }
-
-  public FactorNormalizationFunction(@NotNull final RawDataFilePlaceholder rawDataFilePlaceholder,
-      @Nullable final LocalDateTime acquisitionTimestamp, final double factor) {
-    this.rawDataFilePlaceholder = rawDataFilePlaceholder;
-    this.acquisitionTimestamp = acquisitionTimestamp;
-    this.factor = factor;
-  }
-
-  public FactorNormalizationFunction(@NotNull RawDataFile file, double factor) {
-    this(file, MetadataTableUtils.getRunDate(file), factor);
-  }
-
-  @Override
-  public @NotNull RawDataFilePlaceholder rawDataFilePlaceholder() {
-    return rawDataFilePlaceholder;
-  }
-
-  @Override
-  public @Nullable LocalDateTime acquisitionTimestamp() {
-    return acquisitionTimestamp;
-  }
 
   @Override
   public @NotNull String getUniqueID() {
@@ -82,25 +49,14 @@ public record FactorNormalizationFunction(@NotNull RawDataFilePlaceholder rawDat
   @Override
   public void saveToXML(final @NotNull Element functionElement) {
     functionElement.setAttribute(XML_FUNCTION_TYPE_ATTR, getUniqueID());
-    rawDataFilePlaceholder.saveToXML(functionElement);
-    NormalizationFunction.saveAcquisitionTimestamp(functionElement, acquisitionTimestamp);
     functionElement.setAttribute(XML_FACTOR_ATTR, Double.toString(factor));
   }
 
   public static @NotNull FactorNormalizationFunction loadFromXML(
       final @NotNull Element functionElement) {
-    final RawDataFilePlaceholder rawDataFilePlaceholder = RawDataFilePlaceholder.loadFromXML(
-        functionElement);
-    final LocalDateTime acquisitionTimestamp = NormalizationFunction.loadAcquisitionTimestamp(
-        functionElement);
     final double factor = Double.parseDouble(
         XMLUtils.requireAttribute(functionElement, XML_FACTOR_ATTR));
-    return new FactorNormalizationFunction(rawDataFilePlaceholder, acquisitionTimestamp, factor);
-  }
-
-  @Override
-  public @NotNull NormalizationFunction withRawFile(@NotNull RawDataFile file) {
-    return new FactorNormalizationFunction(file, factor);
+    return new FactorNormalizationFunction(factor);
   }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/FeatureIntensityNormalizationModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/FeatureIntensityNormalizationModule.java
@@ -63,7 +63,7 @@ public class FeatureIntensityNormalizationModule extends AbstractFactorNormaliza
 
     // need to apply any previous normalization function if it is available
     // to apply the next normalization on top of the existing
-    final @Nullable NormalizationFunction existingNormFunction = summary.functions().get(file);
+    final @Nullable RawFileNormalizationFunction existingNormFunction = summary.functions().get(file);
     final double[] abundances = featureList.stream().map(r -> (ModularFeature) r.getFeature(file))
         .filter(Objects::nonNull)
         .mapToDouble(feature -> abundanceMeasure.getOrNaN(feature, existingNormFunction))

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/IntensityNormalizationSearchableSummary.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/IntensityNormalizationSearchableSummary.java
@@ -36,12 +36,13 @@ import org.jetbrains.annotations.Nullable;
 /**
  * This summary is a faster version that is optimized to search the functions for raw data files.
  * This class is used during intensity normalization and may be used when batch reapplying
- * normalization. The related {@link IntensityNormalizationSummary} is used for saving to
- * parameter and xml to save memory on the map and to use Weak references to raw data files to avoid
- * memory leaks.
+ * normalization. The related {@link IntensityNormalizationSummary} is used for saving to parameter
+ * and xml to save memory on the map and to use Weak references to raw data files to avoid memory
+ * leaks.
  */
 public record IntensityNormalizationSearchableSummary(
-    @NotNull Map<RawDataFile, NormalizationFunction> functions, @NotNull List<String> messages) {
+    @NotNull Map<RawDataFile, RawFileNormalizationFunction> functions,
+    @NotNull List<String> messages) {
 
   /**
    * instance with immutable maps and lists
@@ -50,7 +51,7 @@ public record IntensityNormalizationSearchableSummary(
       Map.of(), List.of());
 
   public IntensityNormalizationSearchableSummary(
-      @NotNull Map<RawDataFile, NormalizationFunction> functions) {
+      @NotNull Map<RawDataFile, RawFileNormalizationFunction> functions) {
     this(functions, new ArrayList<>());
   }
 
@@ -70,13 +71,30 @@ public record IntensityNormalizationSearchableSummary(
    * @return the new function either the input or a merged function from the input and previous
    */
   @NotNull
-  public NormalizationFunction addMergeFunction(@NotNull RawDataFile file,
+  public RawFileNormalizationFunction addMergeFunction(@NotNull RawDataFile file,
       @NotNull NormalizationFunction function) {
-    return functions.merge(file, function, NormalizationFunction::merge);
+    return functions.compute(file, (_, oldFunc) -> {
+      if (oldFunc == null) {
+        return new RawFileNormalizationFunction(file, function);
+      }
+
+      NormalizationFunction merged = NormalizationFunction.merge(oldFunc.function(), function);
+      return new RawFileNormalizationFunction(file, merged);
+    });
   }
 
   @Nullable
   public NormalizationFunction get(RawDataFile file) {
+    final RawFileNormalizationFunction fun = functions.get(file);
+    return fun != null ? fun.function() : null;
+  }
+
+  @Nullable
+  public RawFileNormalizationFunction getRawFileFunction(RawDataFile file) {
     return functions.get(file);
+  }
+
+  public int size() {
+    return functions.size();
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/IntensityNormalizationSummary.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/IntensityNormalizationSummary.java
@@ -35,7 +35,7 @@ import org.jetbrains.annotations.NotNull;
  * searchable version is used during normalization building
  * {@link IntensityNormalizationSearchableSummary}
  */
-public record IntensityNormalizationSummary(@NotNull List<NormalizationFunction> functions,
+public record IntensityNormalizationSummary(@NotNull List<RawFileNormalizationFunction> functions,
                                             @NotNull List<String> messages) {
 
   public static final @NotNull IntensityNormalizationSummary EMPTY = new IntensityNormalizationSummary(
@@ -47,7 +47,7 @@ public record IntensityNormalizationSummary(@NotNull List<NormalizationFunction>
   }
 
   public IntensityNormalizationSummary(
-      @NotNull List<NormalizationFunction> functions) {
+      @NotNull List<RawFileNormalizationFunction> functions) {
     this(functions, new ArrayList<>());
   }
 
@@ -57,5 +57,20 @@ public record IntensityNormalizationSummary(@NotNull List<NormalizationFunction>
 
   public boolean isEmpty() {
     return functions.isEmpty();
+  }
+
+  @NotNull
+  public NormalizationFunction get(int index) {
+    if (index < 0 || index >= size()) {
+      throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size());
+    }
+    return functions.get(index).function();
+  }
+  @NotNull
+  public RawFileNormalizationFunction getRawFileFunction(int index) {
+    if (index < 0 || index >= size()) {
+      throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size());
+    }
+    return functions.get(index);
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/IntensityNormalizerModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/IntensityNormalizerModule.java
@@ -99,10 +99,10 @@ public class IntensityNormalizerModule implements MZmineProcessingModule {
    */
   public static @NotNull Optional<NormalizationFunction> getNormalizationFunctionsOfLatestCallForFile(
       final @NotNull FeatureList featureList, final @NotNull RawDataFile rawDataFile) {
-    IntensityNormalizationSummary summary = getNormalizationFunctionsOfLatestCall(
-        featureList);
+    IntensityNormalizationSummary summary = getNormalizationFunctionsOfLatestCall(featureList);
     return summary.functions().stream()
-        .filter(func -> func.rawDataFilePlaceholder().matches(rawDataFile)).findFirst();
+        .filter(func -> func.rawDataFilePlaceholder().matches(rawDataFile))
+        .map(RawFileNormalizationFunction::function).findFirst();
   }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/IntensityNormalizerTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/IntensityNormalizerTask.java
@@ -37,7 +37,6 @@ import io.github.mzmine.datamodel.features.types.DataTypes;
 import io.github.mzmine.datamodel.features.types.numbers.NormalizedAreaType;
 import io.github.mzmine.datamodel.features.types.numbers.NormalizedHeightType;
 import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
-import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTableUtils;
 import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter.OriginalFeatureListOption;
@@ -51,7 +50,6 @@ import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.StringUtils;
 import io.github.mzmine.util.objects.ObjectUtils;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -240,14 +238,13 @@ class IntensityNormalizerTask extends AbstractTask {
     // apply those to all samples in the same batch
     for (SamplesBatch sampleBatch : sampleBatches) {
       final double normFactor = interBatchMedian / sampleBatch.getMedianReferenceNormMetric();
+      // reuse same function for all files in this batch
+      final FactorNormalizationFunction fileFunction = new FactorNormalizationFunction(normFactor);
+
       logger.fine("Normalizing %d samples in batch %s inter batches norm metric=%.4f".formatted(
           sampleBatch.size(), sampleBatch.getGroupMetadataValueStr(), normFactor));
 
       for (RawDataFile raw : sampleBatch.getRaws()) {
-
-        final LocalDateTime runDate = MetadataTableUtils.getRunDate(metadata, raw);
-        final FactorNormalizationFunction fileFunction = new FactorNormalizationFunction(normFactor);
-
         // add and merge function into summary
         summary.addMergeFunction(raw, fileFunction);
         processedFiles++;

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/IntensityNormalizerTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/IntensityNormalizerTask.java
@@ -246,8 +246,7 @@ class IntensityNormalizerTask extends AbstractTask {
       for (RawDataFile raw : sampleBatch.getRaws()) {
 
         final LocalDateTime runDate = MetadataTableUtils.getRunDate(metadata, raw);
-        final FactorNormalizationFunction fileFunction = new FactorNormalizationFunction(raw,
-            runDate, normFactor);
+        final FactorNormalizationFunction fileFunction = new FactorNormalizationFunction(normFactor);
 
         // add and merge function into summary
         summary.addMergeFunction(raw, fileFunction);
@@ -368,15 +367,15 @@ class IntensityNormalizerTask extends AbstractTask {
    * Applies the normalization functions to all features in the feature list.
    */
   private void applyFunctionsToFeatures(@NotNull final ModularFeatureList featureList,
-      @NotNull final Map<RawDataFile, NormalizationFunction> fileToFunction) {
+      final @NotNull Map<RawDataFile, RawFileNormalizationFunction> fileToFunction) {
 
     if (hasFinishedApplyFunctions) {
       throw new IllegalStateException("Cannot apply functions twice. Should only normalize once.");
     }
     hasFinishedApplyFunctions = true;
 
-    for (Entry<RawDataFile, NormalizationFunction> entry : fileToFunction.entrySet()) {
-      final NormalizationFunction fn = entry.getValue();
+    for (Entry<RawDataFile, RawFileNormalizationFunction> entry : fileToFunction.entrySet()) {
+      final NormalizationFunction fn = entry.getValue().function();
       final RawDataFile raw = entry.getKey();
       if (isCanceled()) {
         return;

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/InterpolatedNormalizationFunction.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/InterpolatedNormalizationFunction.java
@@ -24,14 +24,9 @@
 
 package io.github.mzmine.modules.dataprocessing.norm_intensity;
 
-import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTableUtils;
-import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilePlaceholder;
 import io.github.mzmine.util.XMLUtils;
 import io.github.mzmine.util.maths.Precision;
-import java.time.LocalDateTime;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Element;
 
 /**
@@ -41,25 +36,17 @@ import org.w3c.dom.Element;
  * {@link FactorNormalizationFunction}.
  *
  */
-public record InterpolatedNormalizationFunction(
-    @NotNull RawDataFilePlaceholder rawDataFilePlaceholder,
-    @Nullable LocalDateTime acquisitionTimestamp, @NotNull NormalizationFunction previousFunction,
-    double previousWeight, @NotNull NormalizationFunction nextFunction,
-    double nextWeight) implements NormalizationFunction {
+public record InterpolatedNormalizationFunction(@NotNull NormalizationFunction previousFunction,
+                                                double previousWeight,
+                                                @NotNull NormalizationFunction nextFunction,
+                                                double nextWeight) implements
+    NormalizationFunction {
 
   public static final String XML_TYPE = "interpolated";
   private static final String XML_PREVIOUS_WEIGHT_ATTR = "previousWeight";
   private static final String XML_NEXT_WEIGHT_ATTR = "nextWeight";
   private static final String XML_PREVIOUS_FUNCTION_ELEMENT = "previousFunction";
   private static final String XML_NEXT_FUNCTION_ELEMENT = "nextFunction";
-
-  public InterpolatedNormalizationFunction(@NotNull final RawDataFile targetFile,
-      @Nullable final LocalDateTime acquisitionTimestamp,
-      @NotNull final NormalizationFunction previousFunction, final double previousWeight,
-      @NotNull final NormalizationFunction nextFunction, final double nextWeight) {
-    this(new RawDataFilePlaceholder(targetFile), acquisitionTimestamp, previousFunction,
-        previousWeight, nextFunction, nextWeight);
-  }
 
   public InterpolatedNormalizationFunction {
     if (!Precision.equalRelativeSignificance(previousWeight + nextWeight, 1d, 0.00001)) {
@@ -83,28 +70,22 @@ public record InterpolatedNormalizationFunction(
   @Override
   public void saveToXML(final @NotNull Element functionElement) {
     functionElement.setAttribute(XML_FUNCTION_TYPE_ATTR, getUniqueID());
-    rawDataFilePlaceholder.saveToXML(functionElement);
-    NormalizationFunction.saveAcquisitionTimestamp(functionElement, acquisitionTimestamp);
     functionElement.setAttribute(XML_PREVIOUS_WEIGHT_ATTR, Double.toString(previousWeight));
     functionElement.setAttribute(XML_NEXT_WEIGHT_ATTR, Double.toString(nextWeight));
 
     final Element previousElement = functionElement.getOwnerDocument()
         .createElement(XML_PREVIOUS_FUNCTION_ELEMENT);
-    NormalizationFunction.appendFunctionElement(previousElement, previousFunction);
+    previousFunction.saveToXML(previousElement);
     functionElement.appendChild(previousElement);
 
     final Element nextElement = functionElement.getOwnerDocument()
         .createElement(XML_NEXT_FUNCTION_ELEMENT);
-    NormalizationFunction.appendFunctionElement(nextElement, nextFunction);
+    nextFunction.saveToXML(nextElement);
     functionElement.appendChild(nextElement);
   }
 
   public static @NotNull InterpolatedNormalizationFunction loadFromXML(
       final @NotNull Element functionElement) {
-    final RawDataFilePlaceholder rawDataFilePlaceholder = RawDataFilePlaceholder.loadFromXML(
-        functionElement);
-    final LocalDateTime acquisitionTimestamp = NormalizationFunction.loadAcquisitionTimestamp(
-        functionElement);
     final double previousWeight = Double.parseDouble(
         XMLUtils.requireAttribute(functionElement, XML_PREVIOUS_WEIGHT_ATTR));
     final double nextWeight = Double.parseDouble(
@@ -112,27 +93,16 @@ public record InterpolatedNormalizationFunction(
 
     final Element previousFunctionContainer = XMLUtils.findChildElement(functionElement,
         XML_PREVIOUS_FUNCTION_ELEMENT);
-    final Element previousFunctionElement = XMLUtils.findChildElement(previousFunctionContainer,
-        XML_FUNCTION_ELEMENT);
     final NormalizationFunction previousFunction = NormalizationFunction.loadFromXML(
-        previousFunctionElement);
+        previousFunctionContainer);
 
     final Element nextFunctionContainer = XMLUtils.findChildElement(functionElement,
         XML_NEXT_FUNCTION_ELEMENT);
-    final Element nextFunctionElement = XMLUtils.findChildElement(nextFunctionContainer,
-        XML_FUNCTION_ELEMENT);
     final NormalizationFunction nextFunction = NormalizationFunction.loadFromXML(
-        nextFunctionElement);
+        nextFunctionContainer);
 
-    return new InterpolatedNormalizationFunction(rawDataFilePlaceholder, acquisitionTimestamp,
-        previousFunction, previousWeight, nextFunction, nextWeight);
-  }
-
-  @Override
-  public @NotNull NormalizationFunction withRawFile(@NotNull RawDataFile file) {
-    // previous and next are from different files so they are not changing reference to file, only this function
-    return new InterpolatedNormalizationFunction(file, MetadataTableUtils.getRunDate(file),
-        previousFunction, previousWeight, nextFunction, nextWeight);
+    return new InterpolatedNormalizationFunction(previousFunction, previousWeight, nextFunction,
+        nextWeight);
   }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/MetadataColumnNormalizationTypeModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/MetadataColumnNormalizationTypeModule.java
@@ -27,12 +27,10 @@ package io.github.mzmine.modules.dataprocessing.norm_intensity;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
-import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTableUtils;
 import io.github.mzmine.modules.visualization.projectmetadata.table.columns.DoubleMetadataColumn;
 import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.util.MathUtils;
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -98,10 +96,9 @@ public class MetadataColumnNormalizationTypeModule implements NormalizationTypeM
       // correct sample by factor/median to keep general intensity scales
       // could also think about using the factor as is
       final double factor =
-          Double.compare(entry.getValue(), 0) == 0 ? 1 : entry.getValue()/median;
-      final LocalDateTime runDate = MetadataTableUtils.getRunDate(metadata, file);
+          Double.compare(entry.getValue(), 0) == 0 ? 1 : entry.getValue() / median;
       // divide or multiple by factor
-      NormalizationFunction function = new FactorNormalizationFunction(file, runDate,
+      NormalizationFunction function = new FactorNormalizationFunction(
           metadataConfig.mode().isDivide() ? 1d / factor : factor);
 
       // add or merge function into a new instance within summary

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/NormalizationFunction.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/NormalizationFunction.java
@@ -24,15 +24,11 @@
 
 package io.github.mzmine.modules.dataprocessing.norm_intensity;
 
-import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.utils.UniqueIdSupplier;
-import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilePlaceholder;
 import io.github.mzmine.util.XMLUtils;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -40,12 +36,11 @@ import org.w3c.dom.Element;
  * Function that returns a normalization factor for specific feature coordinates.
  */
 public sealed interface NormalizationFunction extends UniqueIdSupplier permits
-    CompositeNormalizationFunction, FactorNormalizationFunction,
-    InterpolatedNormalizationFunction, StandardCompoundNormalizationFunction {
+    CompositeNormalizationFunction, FactorNormalizationFunction, InterpolatedNormalizationFunction,
+    StandardCompoundNormalizationFunction {
 
   String XML_FUNCTION_ELEMENT = "normalizationFunction";
   String XML_FUNCTION_TYPE_ATTR = "type";
-  String XML_ACQUISITION_TIMESTAMP_ATTR = "acquisitionTimestamp";
 
   /**
    * Merges the old and new function. If both are constant factors then the factors are merged into
@@ -60,10 +55,9 @@ public sealed interface NormalizationFunction extends UniqueIdSupplier permits
   static NormalizationFunction merge(@NotNull NormalizationFunction old,
       @NotNull NormalizationFunction function) {
     if (old instanceof FactorNormalizationFunction(
-        var rawFile, var acquisitionTimestamp, double factor
-    ) && function instanceof FactorNormalizationFunction newFactor) {
-      return new FactorNormalizationFunction(rawFile, acquisitionTimestamp,
-          factor * newFactor.factor());
+        double factor
+    ) && function instanceof FactorNormalizationFunction(double factor2)) {
+      return new FactorNormalizationFunction(factor * factor2);
     }
 
     final List<NormalizationFunction> subfunctions = new ArrayList<>();
@@ -98,10 +92,6 @@ public sealed interface NormalizationFunction extends UniqueIdSupplier permits
     return this instanceof FactorNormalizationFunction;
   }
 
-  @NotNull RawDataFilePlaceholder rawDataFilePlaceholder();
-
-  @Nullable LocalDateTime acquisitionTimestamp();
-
   /**
    * @param mz the mz of the feature
    * @param rt the rt of the feature
@@ -111,14 +101,6 @@ public sealed interface NormalizationFunction extends UniqueIdSupplier permits
 
   void saveToXML(@NotNull Element functionElement);
 
-  /**
-   *
-   * @return The data file this normalization applies to. may be null if the file was removed from
-   * the project.
-   */
-  default @Nullable RawDataFile getRawDataFile() {
-    return rawDataFilePlaceholder().getMatchingFile();
-  }
 
   static void appendFunctionElement(final @NotNull Element parentElement,
       final @NotNull NormalizationFunction normalizationFunction) {
@@ -137,34 +119,10 @@ public sealed interface NormalizationFunction extends UniqueIdSupplier permits
           StandardCompoundNormalizationFunction.loadFromXML(functionElement);
       case InterpolatedNormalizationFunction.XML_TYPE ->
           InterpolatedNormalizationFunction.loadFromXML(functionElement);
+      case CompositeNormalizationFunction.XML_TYPE -> CompositeNormalizationFunction.loadFromXML(functionElement);
       default -> throw new IllegalArgumentException(
           "Unsupported normalization function type: " + functionType);
     };
   }
 
-  static void saveAcquisitionTimestamp(final @NotNull Element functionElement,
-      final @Nullable LocalDateTime acquisitionTimestamp) {
-    if (acquisitionTimestamp != null) {
-      functionElement.setAttribute(XML_ACQUISITION_TIMESTAMP_ATTR, acquisitionTimestamp.toString());
-    }
-  }
-
-  static @Nullable LocalDateTime loadAcquisitionTimestamp(final @NotNull Element functionElement) {
-    if (!functionElement.hasAttribute(XML_ACQUISITION_TIMESTAMP_ATTR)) {
-      return null;
-    }
-
-    final String acquisitionTimestamp = functionElement.getAttribute(
-        XML_ACQUISITION_TIMESTAMP_ATTR);
-    if (acquisitionTimestamp.isBlank()) {
-      return null;
-    }
-
-    return LocalDateTime.parse(acquisitionTimestamp);
-  }
-
-  /**
-   * @return Create a copy of the function that points to the new file
-   */
-  @NotNull NormalizationFunction withRawFile(@NotNull RawDataFile file);
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/NormalizationFunctionUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/NormalizationFunctionUtils.java
@@ -35,10 +35,10 @@ import io.github.mzmine.modules.visualization.projectmetadata.table.Interpolatio
 import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
 import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTableUtils;
 import io.github.mzmine.util.StringUtils;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnknownNullability;
 
 public class NormalizationFunctionUtils {
 
@@ -76,7 +76,8 @@ public class NormalizationFunctionUtils {
    */
   public static void interpolateLinearBinary(
       @NotNull IntensityNormalizationSearchableSummary summary, @NotNull SamplesBatch samplesBatch,
-      Map<RawDataFile, NormalizationFunction> refFunctions, @NotNull MetadataTable metadata) {
+      @UnknownNullability Map<@NotNull RawDataFile, @NotNull NormalizationFunction> refFunctions,
+      @NotNull MetadataTable metadata) {
     if (refFunctions.size() == samplesBatch.size()) {
       return;
     } else if (refFunctions.size() > samplesBatch.size()) {
@@ -89,7 +90,6 @@ public class NormalizationFunctionUtils {
       if (refFunctions.containsKey(fileToInterpolate)) {
         continue;
       }
-      final LocalDateTime time = MetadataTableUtils.getRunDate(metadata, fileToInterpolate);
 
       // either binary or single reference sample found
       final InterpolationWeights weights = MetadataTableUtils.extractAcquisitionDateInterpolationWeights(
@@ -98,27 +98,30 @@ public class NormalizationFunctionUtils {
       final NormalizationFunction resultFunction = switch (weights) {
         // use a copy of the single function that was found
         case SingleInterpolationWeight w -> // only one reference found
-            refFunctions.get(w.closestRun()).withRawFile(fileToInterpolate);
+            refFunctions.get(w.closestRun());
 
         // interpolated between two functions
         case BinaryInterpolationWeights w -> {
           // both left and right functions are not null so interpolate between them
-          final NormalizationFunction previousFunction = refFunctions.get(w.previousRun().file());
+          final NormalizationFunction previousFunction = refFunctions.get(
+              w.previousRun().file());
           final NormalizationFunction nextFunction = refFunctions.get(w.nextRun().file());
 
           if (previousFunction == null || nextFunction == null) {
             throw new IllegalStateException(
                 "No reference normalization functions available for file: %s in samples batch %s".formatted(
                     fileToInterpolate.getName(), samplesBatch.getGroupMetadataValueStr()));
-          } else if (previousFunction instanceof FactorNormalizationFunction prev
+          }
+
+          if (previousFunction instanceof FactorNormalizationFunction prev
               && nextFunction instanceof FactorNormalizationFunction next) {
             // special case where simple factor functions can be turned into a new simple function
             final double factor =
                 next.factor() * w.nextRun().weight() + prev.factor() * w.previousRun().weight();
-            yield new FactorNormalizationFunction(fileToInterpolate, time, factor);
+            yield new FactorNormalizationFunction(factor);
           } else {
             // saves both functions to interpolate, works for all cases
-            yield new InterpolatedNormalizationFunction(fileToInterpolate, time, previousFunction,
+            yield new InterpolatedNormalizationFunction(previousFunction,
                 w.previousRun().weight(), nextFunction, w.nextRun().weight());
           }
         }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/NormalizationFunctionsParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/NormalizationFunctionsParameter.java
@@ -115,7 +115,7 @@ public class NormalizationFunctionsParameter implements
 
   @Override
   public void loadValueFromXML(final @NotNull Element xmlElement) {
-    ArrayList<NormalizationFunction> functions = new ArrayList<>();
+    ArrayList<RawFileNormalizationFunction> functions = new ArrayList<>();
     ArrayList<String> messages = new ArrayList<>();
 
     final Element functionsElement;
@@ -128,14 +128,14 @@ public class NormalizationFunctionsParameter implements
       return;
     }
     final NodeList functionElements = functionsElement.getElementsByTagName(
-        NormalizationFunction.XML_FUNCTION_ELEMENT);
+        RawFileNormalizationFunction.XML_PARENT_ELEMENT);
     for (int i = 0; i < functionElements.getLength(); i++) {
       final Node node = functionElements.item(i);
       if (!(node instanceof Element functionElement) || node.getParentNode() != functionsElement) {
         continue;
       }
       try {
-        functions.add(NormalizationFunction.loadFromXML(functionElement));
+        functions.add(RawFileNormalizationFunction.loadFromXML(functionElement));
       } catch (RuntimeException e) {
         logger.log(Level.WARNING, "Error while loading normalization function", e);
         // do not set a summary if loading of a function fails. This will result in wrong results
@@ -168,7 +168,7 @@ public class NormalizationFunctionsParameter implements
     xmlElement.appendChild(funcElement);
 
     for (var function : summary.functions()) {
-      NormalizationFunction.appendFunctionElement(funcElement, function);
+      function.appendFunctionElement(funcElement);
     }
 
     final Element messagesElement = doc.createElement("messages");

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/RawFileNormalizationFunction.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/RawFileNormalizationFunction.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.dataprocessing.norm_intensity;
+
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTableUtils;
+import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilePlaceholder;
+import java.time.LocalDateTime;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Holds a normalization function that should be applied to intensity values of features.
+ *
+ * @param rawDataFilePlaceholder points to the raw data file
+ * @param acquisitionTimestamp   the acquisition time of the raw data file for interpolation or null
+ *                               if unknown
+ * @param function               the function
+ */
+public record RawFileNormalizationFunction(@NotNull RawDataFilePlaceholder rawDataFilePlaceholder,
+                                           @Nullable LocalDateTime acquisitionTimestamp,
+                                           @NotNull NormalizationFunction function) {
+
+
+  public static final String XML_ACQUISITION_TIMESTAMP_ATTR = "acquisitionTimestamp";
+  public static final String XML_PARENT_ELEMENT = "rawFileNormalization";
+
+  public RawFileNormalizationFunction (@NotNull RawDataFile file, @NotNull NormalizationFunction function) {
+    final LocalDateTime runDate = MetadataTableUtils.getRunDate(file);
+    this(new RawDataFilePlaceholder(file), runDate, function);
+  }
+
+  /**
+   *
+   * @return The data file this normalization applies to. may be null if the file was removed from
+   * the project.
+   */
+  public @Nullable RawDataFile getRawDataFile() {
+    return rawDataFilePlaceholder().getMatchingFile();
+  }
+
+  /**
+   * @return Create a copy of the function that points to the new file
+   */
+  public @NotNull RawFileNormalizationFunction withRawFile(@NotNull RawDataFile file) {
+    final LocalDateTime runDate = MetadataTableUtils.getRunDate(file);
+    return new RawFileNormalizationFunction(new RawDataFilePlaceholder(file), runDate, function);
+  }
+
+
+  public void saveToXML(@NotNull Element element) {
+    rawDataFilePlaceholder.saveToXML(element);
+    if (acquisitionTimestamp != null) {
+      element.setAttribute(XML_ACQUISITION_TIMESTAMP_ATTR, acquisitionTimestamp.toString());
+    }
+
+    function.saveToXML(element);
+  }
+
+
+  public void appendFunctionElement(final @NotNull Element parentElement) {
+    final Document document = parentElement.getOwnerDocument();
+    final Element functionElement = document.createElement(XML_PARENT_ELEMENT);
+    saveToXML(functionElement);
+    parentElement.appendChild(functionElement);
+  }
+
+  static @NotNull RawFileNormalizationFunction loadFromXML(final @NotNull Element parentElement) {
+
+    final RawDataFilePlaceholder rawFile = RawDataFilePlaceholder.loadFromXML(parentElement);
+    final LocalDateTime acqTime = loadAcquisitionTimestamp(parentElement);
+
+    final NormalizationFunction func = NormalizationFunction.loadFromXML(parentElement);
+
+    return new RawFileNormalizationFunction(rawFile, acqTime, func);
+  }
+
+  static @Nullable LocalDateTime loadAcquisitionTimestamp(final @NotNull Element functionElement) {
+    if (!functionElement.hasAttribute(XML_ACQUISITION_TIMESTAMP_ATTR)) {
+      return null;
+    }
+
+    final String acquisitionTimestamp = functionElement.getAttribute(
+        XML_ACQUISITION_TIMESTAMP_ATTR);
+    if (acquisitionTimestamp.isBlank()) {
+      return null;
+    }
+
+    return LocalDateTime.parse(acquisitionTimestamp);
+  }
+
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/StandardCompoundNormalizationFunction.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/StandardCompoundNormalizationFunction.java
@@ -24,26 +24,19 @@
 
 package io.github.mzmine.modules.dataprocessing.norm_intensity;
 
-import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTableUtils;
-import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilePlaceholder;
 import io.github.mzmine.util.XMLUtils;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 /**
  * File-specific standard compound normalization function.
  */
-public record StandardCompoundNormalizationFunction(
-    @NotNull RawDataFilePlaceholder rawDataFilePlaceholder,
-    @Nullable LocalDateTime acquisitionTimestamp, @NotNull StandardUsageType usageType,
-    double mzVsRtBalance,
-    @NotNull List<@NotNull StandardCompoundReferencePoint> referencePoints) implements
+public record StandardCompoundNormalizationFunction(@NotNull StandardUsageType usageType,
+                                                    double mzVsRtBalance,
+                                                    @NotNull List<@NotNull StandardCompoundReferencePoint> referencePoints) implements
     NormalizationFunction {
 
   public static final String XML_TYPE = "standardCompound";
@@ -59,25 +52,6 @@ public record StandardCompoundNormalizationFunction(
     if (referencePoints.isEmpty()) {
       throw new IllegalStateException("No standard reference points available.");
     }
-  }
-
-  public StandardCompoundNormalizationFunction(@NotNull final RawDataFile referenceFile,
-      @Nullable final LocalDateTime acquisitionTimestamp,
-      @NotNull final StandardUsageType usageType,
-      final double mzVsRtBalance,
-      @NotNull final List<StandardCompoundReferencePoint> referencePoints) {
-    this(new RawDataFilePlaceholder(referenceFile), acquisitionTimestamp, usageType, mzVsRtBalance,
-        referencePoints);
-  }
-
-  @Override
-  public @NotNull RawDataFilePlaceholder rawDataFilePlaceholder() {
-    return rawDataFilePlaceholder;
-  }
-
-  @Override
-  public @Nullable LocalDateTime acquisitionTimestamp() {
-    return acquisitionTimestamp;
   }
 
   @Override
@@ -153,8 +127,6 @@ public record StandardCompoundNormalizationFunction(
   @Override
   public void saveToXML(final @NotNull Element functionElement) {
     functionElement.setAttribute(XML_FUNCTION_TYPE_ATTR, getUniqueID());
-    rawDataFilePlaceholder.saveToXML(functionElement);
-    NormalizationFunction.saveAcquisitionTimestamp(functionElement, acquisitionTimestamp);
     functionElement.setAttribute(XML_STANDARD_USAGE_TYPE_ATTR, usageType.name());
     functionElement.setAttribute(XML_MZ_VS_RT_BALANCE_ATTR, Double.toString(mzVsRtBalance));
 
@@ -171,10 +143,6 @@ public record StandardCompoundNormalizationFunction(
 
   public static @NotNull StandardCompoundNormalizationFunction loadFromXML(
       final @NotNull Element functionElement) {
-    final RawDataFilePlaceholder rawDataFilePlaceholder = RawDataFilePlaceholder.loadFromXML(
-        functionElement);
-    final LocalDateTime acquisitionTimestamp = NormalizationFunction.loadAcquisitionTimestamp(
-        functionElement);
     final StandardUsageType standardUsageType = StandardUsageType.valueOf(
         XMLUtils.requireAttribute(functionElement, XML_STANDARD_USAGE_TYPE_ATTR));
     final double mzVsRtBalance = Double.parseDouble(
@@ -193,13 +161,8 @@ public record StandardCompoundNormalizationFunction(
       referencePoints.add(new StandardCompoundReferencePoint(mz, rt, abundance));
     }
 
-    return new StandardCompoundNormalizationFunction(rawDataFilePlaceholder, acquisitionTimestamp,
-        standardUsageType, mzVsRtBalance, referencePoints);
-  }
-
-  @Override
-  public @NotNull NormalizationFunction withRawFile(@NotNull RawDataFile file) {
-    return new StandardCompoundNormalizationFunction(file, MetadataTableUtils.getRunDate(file), usageType, mzVsRtBalance, referencePoints);
+    return new StandardCompoundNormalizationFunction(standardUsageType, mzVsRtBalance,
+        referencePoints);
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/StandardCompoundNormalizationTypeModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/StandardCompoundNormalizationTypeModule.java
@@ -31,9 +31,7 @@ import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
-import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTableUtils;
 import io.github.mzmine.parameters.ParameterSet;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -91,13 +89,12 @@ public class StandardCompoundNormalizationTypeModule extends NormalizationTypeWi
     for (final RawDataFile rawFile : referenceFiles) {
       final List<StandardCompoundReferencePoint> referencePoints = createReferencePoints(summary,
           rawFile, standardRows, abundanceMeasure, requireAllStandards);
-      final LocalDateTime acquisitionTimestamp = MetadataTableUtils.getRunDate(metadata, rawFile);
-      NormalizationFunction function = new StandardCompoundNormalizationFunction(rawFile,
-          acquisitionTimestamp, standardUsageType, mzVsRtBalance, referencePoints);
+      NormalizationFunction function = new StandardCompoundNormalizationFunction(standardUsageType, mzVsRtBalance, referencePoints);
 
       // add or merge function into a new instance within summary
-      function = summary.addMergeFunction(rawFile, function);
+      summary.addMergeFunction(rawFile, function);
 
+      // return the actual function of this step for interpolation
       fileToFunction.put(rawFile, function);
     }
     return fileToFunction;
@@ -132,7 +129,7 @@ public class StandardCompoundNormalizationTypeModule extends NormalizationTypeWi
       }
 
       // apply existing function to abundance to normalize on already normalized values
-      final @Nullable NormalizationFunction existingFunction = summary.functions().get(rawFile);
+      final @Nullable RawFileNormalizationFunction existingFunction = summary.functions().get(rawFile);
 
       final float standardAbundance = abundanceMeasure.getOrNaN(standardFeature, existingFunction);
       if (Float.compare(standardAbundance, 0.0f) == 0 || !Float.isFinite(standardAbundance)) {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/SampleType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/SampleType.java
@@ -28,6 +28,7 @@ package io.github.mzmine.modules.visualization.projectmetadata;
 import io.github.mzmine.datamodel.RawDataFile;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public enum SampleType {
   BLANK, SAMPLE, QC, CALIBRATION;
@@ -35,7 +36,12 @@ public enum SampleType {
   /**
    * checks for naming patterns in the sample name. default return is {@link #SAMPLE}.
    */
-  public static SampleType ofString(String sampleType) {
+  @NotNull
+  public static SampleType ofString(@Nullable String sampleType) {
+    if (sampleType == null) {
+      // TODO maybe change to UNDEFINED
+      return SAMPLE;
+    }
     final String name = sampleType.toLowerCase();
     final Pattern qcPattern = Pattern.compile(".*(?<![a-z])*([-_0-9]*qc[-_0-9]*)(?![a-z])*.*");
     final Pattern blankPattern = Pattern.compile(

--- a/mzmine-community/src/main/java/io/github/mzmine/util/XMLUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/XMLUtils.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Objects;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -49,23 +51,19 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
-import org.xml.sax.SAXException;
 
 /**
  * XML processing utilities
  */
 public class XMLUtils {
 
-  private static final String FEATURE_DISALLOW_DOCTYPE_DECL =
-      "http://apache.org/xml/features/disallow-doctype-decl";
-  private static final String FEATURE_EXTERNAL_GENERAL_ENTITIES =
-      "http://xml.org/sax/features/external-general-entities";
-  private static final String FEATURE_EXTERNAL_PARAMETER_ENTITIES =
-      "http://xml.org/sax/features/external-parameter-entities";
-  private static final String FEATURE_LOAD_EXTERNAL_DTD =
-      "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+  private static final String FEATURE_DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
+  private static final String FEATURE_EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+  private static final String FEATURE_EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
+  private static final String FEATURE_LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
 
   private XMLUtils() {
   }
@@ -103,8 +101,8 @@ public class XMLUtils {
       factory.setFeature(FEATURE_EXTERNAL_PARAMETER_ENTITIES, false);
       factory.setFeature(FEATURE_LOAD_EXTERNAL_DTD, false);
     } catch (SAXNotRecognizedException | SAXNotSupportedException exception) {
-      final ParserConfigurationException parserConfigurationException =
-          new ParserConfigurationException("Failed to configure secure SAX parser factory.");
+      final ParserConfigurationException parserConfigurationException = new ParserConfigurationException(
+          "Failed to configure secure SAX parser factory.");
       parserConfigurationException.initCause(exception);
       throw parserConfigurationException;
     }
@@ -362,5 +360,22 @@ public class XMLUtils {
     }
     throw new IllegalArgumentException(
         "Missing required child element '" + tagName + "' in " + parent.getTagName());
+  }
+
+  /**
+   * Only streams over direct children, not recursively. The method
+   * {@link Element#getElementsByTagName(String)} goes too deep into sub children.
+   *
+   * @param parent element to search in
+   * @param tagName children tag name
+   * @return stream over all direct children with tag name
+   */
+  @NotNull
+  public static Stream<@NotNull Element> streamChildElementsByTagName(@NotNull Element parent,
+      @NotNull String tagName) {
+    NodeList children = parent.getChildNodes();
+    return IntStream.range(0, children.getLength()).mapToObj(children::item)
+        .filter(Element.class::isInstance).map(Element.class::cast)
+        .filter(element -> Objects.equals(element.getTagName(), tagName));
   }
 }

--- a/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/AverageIntensityNormalizationTypeModuleTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/AverageIntensityNormalizationTypeModuleTest.java
@@ -108,20 +108,23 @@ class AverageIntensityNormalizationTypeModuleTest {
     final ModularFeatureList featureList = new ModularFeatureList("flist", null, prevFile,
         targetFile, nextFile);
 
-    final FactorNormalizationFunction prevFunction = new FactorNormalizationFunction(prevFile,
-        prevFile.getStartTimeStamp(), 2d);
-    final FactorNormalizationFunction nextFunction = new FactorNormalizationFunction(nextFile,
-        nextFile.getStartTimeStamp(), 4d);
+    final FactorNormalizationFunction prevFunction = new FactorNormalizationFunction(2d);
+    final FactorNormalizationFunction nextFunction = new FactorNormalizationFunction(4d);
 
     final IntensityNormalizationSearchableSummary summary = new IntensityNormalizationSearchableSummary(
         featureList.getNumberOfRawDataFiles());
     summary.addMergeFunction(prevFile, prevFunction);
     summary.addMergeFunction(nextFile, nextFunction);
 
+    // internally we never use summary.functions for interpolation because
+    // interpolation should be based on a single steps functions not on the merged composite function
+    Map<RawDataFile, NormalizationFunction> functions = Map.of(prevFile, prevFunction, nextFile,
+        nextFunction);
+
     // apply interpolation in module
     module.interpolateAllFunctionsToSummary(summary, featureList,
-        new SamplesBatch(featureList.getRawDataFiles()), new MetadataTable(false),
-        summary.functions(), createMainParameters(AbundanceMeasure.Height),
+        new SamplesBatch(featureList.getRawDataFiles()), new MetadataTable(false), functions,
+        createMainParameters(AbundanceMeasure.Height),
         createFeatureIntensityParametersAllSamples(FeatureIntensityNormalizationMode.AVERAGE));
 
     // will check if interpolation is needed to then interpolate functions and save them to summary

--- a/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/FeatureIntensityNormalizationModuleTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/FeatureIntensityNormalizationModuleTest.java
@@ -30,6 +30,7 @@ import static io.github.mzmine.modules.dataprocessing.norm_intensity.NormIntensi
 import static io.github.mzmine.modules.dataprocessing.norm_intensity.NormIntensityTestUtils.createRawFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -73,8 +74,13 @@ class FeatureIntensityNormalizationModuleTest {
     // Median(file_a)=2.5 and Median(file_b)=1.0 => median=3.5/2
     assertEquals(3.5/2d/2.5, functionA.getNormalizationFactor(0d, 0f), 1e-12);
     assertEquals(3.5/2d/1d, functionB.getNormalizationFactor(0d, 0f), 1e-12);
-    assertEquals(fileA.getStartTimeStamp(), functionA.acquisitionTimestamp());
-    assertEquals(fileB.getStartTimeStamp(), functionB.acquisitionTimestamp());
+
+    final RawFileNormalizationFunction rawFileFuncA = summary.getRawFileFunction(fileA);
+    final RawFileNormalizationFunction rawFileFuncB = summary.getRawFileFunction(fileB);
+    assertNotNull(rawFileFuncA);
+    assertNotNull(rawFileFuncB);
+    assertEquals(fileA.getStartTimeStamp(), rawFileFuncA.acquisitionTimestamp());
+    assertEquals(fileB.getStartTimeStamp(), rawFileFuncB.acquisitionTimestamp());
   }
 
   @Test
@@ -167,8 +173,12 @@ class FeatureIntensityNormalizationModuleTest {
     final FactorNormalizationFunction functionB = assertInstanceOf(
         FactorNormalizationFunction.class, functions.get(fileB));
 
-    assertNull(functionA.acquisitionTimestamp());
-    assertNull(functionB.acquisitionTimestamp());
+    final RawFileNormalizationFunction rawFileFuncA = summary.getRawFileFunction(fileA);
+    final RawFileNormalizationFunction rawFileFuncB = summary.getRawFileFunction(fileB);
+    assertNotNull(rawFileFuncA);
+    assertNotNull(rawFileFuncB);
+    assertNull(rawFileFuncA.acquisitionTimestamp());
+    assertNull(rawFileFuncB.acquisitionTimestamp());
     // median a=2 median b=8 total median is 5
     assertEquals(5d/2d, functionA.getNormalizationFactor(0d, 0f), 1e-12);
     assertEquals(5d/8d, functionB.getNormalizationFactor(0d, 0f), 1e-12);

--- a/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/InterpolatedNormalizationFunctionTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/InterpolatedNormalizationFunctionTest.java
@@ -27,24 +27,17 @@ package io.github.mzmine.modules.dataprocessing.norm_intensity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.github.mzmine.datamodel.RawDataFile;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 class InterpolatedNormalizationFunctionTest {
 
   @Test
   void constructorThrowsIfWeightsDoNotSumToOne() {
-    final RawDataFile file = RawDataFile.createDummyFile();
-    final LocalDateTime timestamp = LocalDateTime.of(2026, 1, 1, 10, 0);
-    final FactorNormalizationFunction previousFunction = new FactorNormalizationFunction(file,
-        timestamp, 2d);
-    final FactorNormalizationFunction nextFunction = new FactorNormalizationFunction(file,
-        timestamp, 4d);
+    final FactorNormalizationFunction previousFunction = new FactorNormalizationFunction(2d);
+    final FactorNormalizationFunction nextFunction = new FactorNormalizationFunction(4d);
 
     final IllegalStateException exception = assertThrows(IllegalStateException.class,
-        () -> new InterpolatedNormalizationFunction(file, timestamp, previousFunction, 0.8d,
-            nextFunction, 0.8d));
+        () -> new InterpolatedNormalizationFunction(previousFunction, 0.8d, nextFunction, 0.8d));
 
     assertEquals("Sum of previous and next run weight must be 1. prev=0.800000, next=0.800000",
         exception.getMessage());
@@ -52,15 +45,11 @@ class InterpolatedNormalizationFunctionTest {
 
   @Test
   void getNormalizationFactorInterpolatesPreviousAndNextFunctions() {
-    final RawDataFile file = RawDataFile.createDummyFile();
-    final LocalDateTime timestamp = LocalDateTime.of(2026, 1, 1, 10, 0);
-    final FactorNormalizationFunction previousFunction = new FactorNormalizationFunction(file,
-        timestamp, 2d);
-    final FactorNormalizationFunction nextFunction = new FactorNormalizationFunction(file,
-        timestamp, 4d);
+    final FactorNormalizationFunction previousFunction = new FactorNormalizationFunction(2d);
+    final FactorNormalizationFunction nextFunction = new FactorNormalizationFunction(4d);
 
     final InterpolatedNormalizationFunction interpolation = new InterpolatedNormalizationFunction(
-        file, timestamp, previousFunction, 0.25d, nextFunction, 0.75d);
+        previousFunction, 0.25d, nextFunction, 0.75d);
 
     assertEquals(3.5d, interpolation.getNormalizationFactor(100d, 5f), 1e-12);
   }

--- a/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/MetadataColumnNormalizationTypeModuleTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/MetadataColumnNormalizationTypeModuleTest.java
@@ -69,14 +69,14 @@ class MetadataColumnNormalizationTypeModuleTest {
       module.createAllNormalizationFunctionsToSummary(summary, featureList,
           new SamplesBatch(featureList.getRawDataFiles(), null), metadata,
           createMainParameters(AbundanceMeasure.Height), moduleParameters);
-      final Map<RawDataFile, NormalizationFunction> functions = summary.functions();
+      final Map<RawDataFile, RawFileNormalizationFunction> functions = summary.functions();
 
       final FactorNormalizationFunction functionA = assertInstanceOf(
-          FactorNormalizationFunction.class, functions.get(fileA));
+          FactorNormalizationFunction.class, summary.get(fileA));
       final FactorNormalizationFunction functionB = assertInstanceOf(
-          FactorNormalizationFunction.class, functions.get(fileB));
+          FactorNormalizationFunction.class, summary.get(fileB));
       final FactorNormalizationFunction functionC = assertInstanceOf(
-          FactorNormalizationFunction.class, functions.get(fileC));
+          FactorNormalizationFunction.class, summary.get(fileC));
 
       assertEquals(3, functions.size());
       assertEquals(0.5d, functionA.getNormalizationFactor(0d, 0f), 1e-12);
@@ -94,16 +94,15 @@ class MetadataColumnNormalizationTypeModuleTest {
       module.createAllNormalizationFunctionsToSummary(summary, featureList,
           new SamplesBatch(featureList.getRawDataFiles(), null), metadata,
           createMainParameters(AbundanceMeasure.Height), moduleParameters);
-      final Map<RawDataFile, NormalizationFunction> functions = summary.functions();
 
       final FactorNormalizationFunction functionA = assertInstanceOf(
-          FactorNormalizationFunction.class, functions.get(fileA));
+          FactorNormalizationFunction.class, summary.get(fileA));
       final FactorNormalizationFunction functionB = assertInstanceOf(
-          FactorNormalizationFunction.class, functions.get(fileB));
+          FactorNormalizationFunction.class, summary.get(fileB));
       final FactorNormalizationFunction functionC = assertInstanceOf(
-          FactorNormalizationFunction.class, functions.get(fileC));
+          FactorNormalizationFunction.class, summary.get(fileC));
 
-      assertEquals(3, functions.size());
+      assertEquals(3, summary.size());
       assertEquals(2d, functionA.getNormalizationFactor(0d, 0f), 1e-12);
       assertEquals(1d, functionB.getNormalizationFactor(0d, 0f), 1e-12);
       assertEquals(2d / 5d, functionC.getNormalizationFactor(0d, 0f), 1e-12);
@@ -130,12 +129,11 @@ class MetadataColumnNormalizationTypeModuleTest {
     module.createAllNormalizationFunctionsToSummary(summary, featureList,
         new SamplesBatch(featureList.getRawDataFiles(), null), metadata,
         createMainParameters(AbundanceMeasure.Height), moduleParameters);
-    final Map<RawDataFile, NormalizationFunction> functions = summary.functions();
 
     final FactorNormalizationFunction functionA = assertInstanceOf(
-        FactorNormalizationFunction.class, functions.get(fileA));
+        FactorNormalizationFunction.class, summary.get(fileA));
     final FactorNormalizationFunction functionB = assertInstanceOf(
-        FactorNormalizationFunction.class, functions.get(fileB));
+        FactorNormalizationFunction.class, summary.get(fileB));
 
     assertEquals(0.5d, functionA.getNormalizationFactor(0d, 0f), 1e-12);
     assertEquals(1d, functionB.getNormalizationFactor(0d, 0f), 1e-12);

--- a/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/NormalizationFunctionsParameterTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/NormalizationFunctionsParameterTest.java
@@ -42,84 +42,103 @@ import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsSelectio
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsSelectionType;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilePlaceholder;
 import io.github.mzmine.util.XMLUtils;
-import java.nio.file.Path;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 class NormalizationFunctionsParameterTest {
 
-  @TempDir
-  Path tempDir;
+  final LocalDateTime factorTimestamp = LocalDateTime.of(2026, 1, 1, 10, 0);
+  final LocalDateTime standardTimestamp = LocalDateTime.of(2026, 1, 1, 10, 10);
+  final LocalDateTime interpolatedTimestamp = LocalDateTime.of(2026, 1, 1, 10, 5);
+  final LocalDateTime compositeTimestamp = LocalDateTime.of(2026, 1, 1, 10, 15);
+  final RawDataFilePlaceholder factorFile = createRawFile("factor_file");
+  final RawDataFilePlaceholder standardFile = createRawFile("standard_file");
+  final RawDataFilePlaceholder interpolatedFile = createRawFile("target_file");
+  final RawDataFilePlaceholder compositeFile = createRawFile("composite_file");
+
+  final double FACTOR = 2d;
+  final RawFileNormalizationFunction factorFunction = createFactorFunction(factorFile,
+      factorTimestamp, FACTOR);
+  final RawFileNormalizationFunction standardFunction = new RawFileNormalizationFunction(
+      standardFile, standardTimestamp,
+      new StandardCompoundNormalizationFunction(StandardUsageType.Nearest, 1d,
+          List.of(new StandardCompoundReferencePoint(100d, 5f, 200d))));
+  final RawFileNormalizationFunction interpolatedFunction = new RawFileNormalizationFunction(
+      interpolatedFile, interpolatedTimestamp,
+      new InterpolatedNormalizationFunction(factorFunction.function(), 0.25d,
+          standardFunction.function(), 0.75d));
+
+  final RawFileNormalizationFunction compositeFunction = new RawFileNormalizationFunction(
+      compositeFile, compositeTimestamp, new CompositeNormalizationFunction(
+      List.of(factorFunction.function(), standardFunction.function(),
+          interpolatedFunction.function())));
 
   @Test
   void saveLoadRoundtripKeepsAllFunctionTypes() {
-    final LocalDateTime factorTimestamp = LocalDateTime.of(2026, 1, 1, 10, 0);
-    final LocalDateTime standardTimestamp = LocalDateTime.of(2026, 1, 1, 10, 10);
-    final LocalDateTime interpolatedTimestamp = LocalDateTime.of(2026, 1, 1, 10, 5);
-
-    final FactorNormalizationFunction factorFunction = new FactorNormalizationFunction(
-        new RawDataFilePlaceholder("factor_file", tempDir.resolve("factor.mzML").toString(), 11),
-        factorTimestamp, 2d);
-    final StandardCompoundNormalizationFunction standardFunction = new StandardCompoundNormalizationFunction(
-        new RawDataFilePlaceholder("standard_file", tempDir.resolve("standard.mzML").toString(),
-            12), standardTimestamp, StandardUsageType.Nearest, 1d,
-        List.of(new StandardCompoundReferencePoint(100d, 5f, 200d)));
-    final InterpolatedNormalizationFunction interpolatedFunction = new InterpolatedNormalizationFunction(
-        new RawDataFilePlaceholder("target_file", tempDir.resolve("target.mzML").toString(), 13),
-        interpolatedTimestamp, factorFunction, 0.25d, standardFunction, 0.75d);
 
     final NormalizationFunctionsParameter parameter = new NormalizationFunctionsParameter();
-    parameter.setValue(createSummary(factorFunction, standardFunction, interpolatedFunction));
+    final IntensityNormalizationSummary savedSummary = createSummary(factorFunction,
+        standardFunction, interpolatedFunction, compositeFunction);
+    parameter.setValue(savedSummary);
 
     final String xml = ParameterUtils.saveParameterToXMLString(parameter);
     final NormalizationFunctionsParameter loadedParameter = new NormalizationFunctionsParameter();
     ParameterUtils.loadParameterFromString(loadedParameter, xml);
 
     final IntensityNormalizationSummary summary = loadedParameter.getValue();
-    final List<NormalizationFunction> loadedFunctions = summary.functions();
-    assertEquals(3, loadedFunctions.size());
+    final List<RawFileNormalizationFunction> loadedFunctions = summary.functions();
+    assertEquals(savedSummary.size(), loadedFunctions.size());
+
+    for (int i = 0; i < summary.functions().size(); i++) {
+      final RawFileNormalizationFunction original = savedSummary.getRawFileFunction(i);
+      final RawFileNormalizationFunction loaded = summary.getRawFileFunction(i);
+      assertEquals(original.rawDataFilePlaceholder().getName(),
+          loaded.rawDataFilePlaceholder().getName());
+    }
+
+    // placeholder has no acquisition date so need to check manually
+    assertEquals(factorTimestamp, summary.getRawFileFunction(0).acquisitionTimestamp());
+    assertEquals(standardTimestamp, summary.getRawFileFunction(1).acquisitionTimestamp());
+    assertEquals(interpolatedTimestamp, summary.getRawFileFunction(2).acquisitionTimestamp());
+    assertEquals(compositeTimestamp, summary.getRawFileFunction(3).acquisitionTimestamp());
 
     final FactorNormalizationFunction loadedFactor = assertInstanceOf(
-        FactorNormalizationFunction.class, loadedFunctions.get(0));
-    assertEquals("factor_file", loadedFactor.rawDataFilePlaceholder().getName());
-    assertEquals(factorTimestamp, loadedFactor.acquisitionTimestamp());
+        FactorNormalizationFunction.class, summary.get(0));
     assertEquals(2d, loadedFactor.getNormalizationFactor(0d, 0f), 1e-12);
 
     final StandardCompoundNormalizationFunction loadedStandard = assertInstanceOf(
-        StandardCompoundNormalizationFunction.class, loadedFunctions.get(1));
-    assertEquals("standard_file", loadedStandard.rawDataFilePlaceholder().getName());
-    assertEquals(standardTimestamp, loadedStandard.acquisitionTimestamp());
+        StandardCompoundNormalizationFunction.class, summary.get(1));
     assertEquals(StandardUsageType.Nearest, loadedStandard.usageType());
     assertEquals(1, loadedStandard.referencePoints().size());
     assertEquals(0.005d, loadedStandard.getNormalizationFactor(100d, 5f), 1e-12);
 
     final InterpolatedNormalizationFunction loadedInterpolated = assertInstanceOf(
-        InterpolatedNormalizationFunction.class, loadedFunctions.get(2));
-    assertEquals("target_file", loadedInterpolated.rawDataFilePlaceholder().getName());
-    assertEquals(interpolatedTimestamp, loadedInterpolated.acquisitionTimestamp());
+        InterpolatedNormalizationFunction.class, summary.get(2));
     assertEquals(0.25d, loadedInterpolated.previousWeight(), 1e-12);
     assertEquals(0.75d, loadedInterpolated.nextWeight(), 1e-12);
     assertEquals(0.50375d, loadedInterpolated.getNormalizationFactor(100d, 5f), 1e-12);
+
+    final CompositeNormalizationFunction loadedComposite = assertInstanceOf(
+        CompositeNormalizationFunction.class, summary.get(3));
+    assertEquals(3, loadedComposite.functions().size());
   }
 
   @Test
   void loadValueFromXMLResultsInEmptyFunctionsOnExceptionToRead() throws Exception {
     final LocalDateTime timestamp = LocalDateTime.of(2026, 1, 1, 10, 0);
-    final FactorNormalizationFunction validFunction = new FactorNormalizationFunction(
-        new RawDataFilePlaceholder("valid_file", tempDir.resolve("valid.mzML").toString(), 7),
-        timestamp, 2d);
+    final RawFileNormalizationFunction validFunction = createFactorFunction(
+        createRawFile("valid_file"), timestamp, 2d);
 
     final Document document = XMLUtils.newDocument();
     final Element root = document.createElement("normalizationFunctions");
     document.appendChild(root);
 
-    NormalizationFunction.appendFunctionElement(root, validFunction);
+    NormalizationFunction.appendFunctionElement(root, validFunction.function());
 
     final Element invalidFunction = document.createElement(
         NormalizationFunction.XML_FUNCTION_ELEMENT);
@@ -142,12 +161,8 @@ class NormalizationFunctionsParameterTest {
 
   @Test
   void hiddenParameterInNormalizerParameterSetPersistsFunctions() throws Exception {
-    final LocalDateTime timestamp = LocalDateTime.of(2026, 1, 2, 10, 0);
-    final List<NormalizationFunction> functions = List.of(new FactorNormalizationFunction(
-        new RawDataFilePlaceholder("file_a", tempDir.resolve("a.mzML").toString(), 42), timestamp,
-        1.25d));
     final IntensityNormalizerParameters parameters = createIntensityParameters("hidden_save",
-        AbundanceMeasure.Height, OriginalFeatureListOption.KEEP, functions);
+        AbundanceMeasure.Height, OriginalFeatureListOption.KEEP, List.of(factorFunction));
 
     final String xml = ParameterUtils.saveValuesToXMLString(parameters);
     final IntensityNormalizerParameters loaded = createIntensityParameters("placeholder",
@@ -160,11 +175,12 @@ class NormalizationFunctionsParameterTest {
     assertEquals(1, summary.size());
     var loadedFunctions = summary.functions();
     assertEquals(1, loadedFunctions.size());
+    final RawFileNormalizationFunction rawFunc = loadedFunctions.getFirst();
     final FactorNormalizationFunction loadedFactor = assertInstanceOf(
-        FactorNormalizationFunction.class, loadedFunctions.getFirst());
-    assertEquals("file_a", loadedFactor.rawDataFilePlaceholder().getName());
-    assertEquals(timestamp, loadedFactor.acquisitionTimestamp());
-    assertEquals(1.25d, loadedFactor.getNormalizationFactor(0d, 0f), 1e-12);
+        FactorNormalizationFunction.class, rawFunc.function());
+    assertEquals(factorFile.getName(), rawFunc.rawDataFilePlaceholder().getName());
+    assertEquals(factorTimestamp, rawFunc.acquisitionTimestamp());
+    assertEquals(FACTOR, loadedFactor.getNormalizationFactor(0d, 0f), 1e-12);
   }
 
   @Test
@@ -174,7 +190,7 @@ class NormalizationFunctionsParameterTest {
 
     final IntensityNormalizerParameters olderParameters = createIntensityParameters("older",
         AbundanceMeasure.Height, OriginalFeatureListOption.KEEP, List.of(
-            new FactorNormalizationFunction(new RawDataFilePlaceholder(rawDataFile),
+            createFactorFunction(new RawDataFilePlaceholder(rawDataFile),
                 LocalDateTime.of(2026, 1, 1, 9, 0), 2d)));
     featureList.addDescriptionOfAppliedTask(
         new SimpleFeatureListAppliedMethod(IntensityNormalizerModule.class, olderParameters,
@@ -182,7 +198,7 @@ class NormalizationFunctionsParameterTest {
 
     final IntensityNormalizerParameters latestParameters = createIntensityParameters("latest",
         AbundanceMeasure.Height, OriginalFeatureListOption.KEEP, List.of(
-            new FactorNormalizationFunction(new RawDataFilePlaceholder(rawDataFile),
+            createFactorFunction(new RawDataFilePlaceholder(rawDataFile),
                 LocalDateTime.of(2026, 1, 1, 11, 0), 3d)));
     featureList.addDescriptionOfAppliedTask(
         new SimpleFeatureListAppliedMethod(IntensityNormalizerModule.class, latestParameters,
@@ -192,9 +208,9 @@ class NormalizationFunctionsParameterTest {
         featureList);
     assertNotNull(summary);
     assertEquals(1, summary.size());
-    final List<NormalizationFunction> latestFunctions = summary.functions();
+    final List<RawFileNormalizationFunction> latestFunctions = summary.functions();
     assertEquals(1, latestFunctions.size());
-    assertEquals(3d, latestFunctions.getFirst().getNormalizationFactor(100d, 5f), 1e-12);
+    assertEquals(3d, latestFunctions.getFirst().function().getNormalizationFactor(100d, 5f), 1e-12);
 
     final NormalizationFunction latestForFile = IntensityNormalizerModule.getNormalizationFunctionsOfLatestCallForFile(
         featureList, rawDataFile).get();
@@ -202,9 +218,7 @@ class NormalizationFunctionsParameterTest {
     assertEquals(3d, latestForFile.getNormalizationFactor(100d, 5f), 1e-12);
 
     final NormalizationFunction missingFile = IntensityNormalizerModule.getNormalizationFunctionsOfLatestCallForFile(
-            featureList,
-            new RawDataFilePlaceholder("unknown", tempDir.resolve("unknown.mzML").toString(), 999))
-        .orElse(null);
+        featureList, createRawFile("unknown")).orElse(null);
     assertNull(missingFile);
   }
 
@@ -221,10 +235,10 @@ class NormalizationFunctionsParameterTest {
 
   @Test
   void saveLoadRoundtripPreservesWeightedUsageType() {
-    final StandardCompoundNormalizationFunction function = new StandardCompoundNormalizationFunction(
-        new RawDataFilePlaceholder("file", tempDir.resolve("file.mzML").toString(), 1),
-        LocalDateTime.of(2026, 1, 1, 10, 0), StandardUsageType.Weighted, 1d,
-        List.of(new StandardCompoundReferencePoint(100d, 5f, 200d)));
+    final RawFileNormalizationFunction function = new RawFileNormalizationFunction(
+        createRawFile("file"), LocalDateTime.of(2026, 1, 1, 10, 0),
+        new StandardCompoundNormalizationFunction(StandardUsageType.Weighted, 1d,
+            List.of(new StandardCompoundReferencePoint(100d, 5f, 200d))));
 
     final NormalizationFunctionsParameter parameter = new NormalizationFunctionsParameter();
     parameter.setValue(createSummary(function));
@@ -234,17 +248,18 @@ class NormalizationFunctionsParameterTest {
     ParameterUtils.loadParameterFromString(loaded, xml);
 
     final StandardCompoundNormalizationFunction loadedFunction = assertInstanceOf(
-        StandardCompoundNormalizationFunction.class, loaded.getValue().functions().getFirst());
+        StandardCompoundNormalizationFunction.class,
+        loaded.getValue().functions().getFirst().function());
     assertEquals(StandardUsageType.Weighted, loadedFunction.usageType());
   }
 
   private static @NotNull IntensityNormalizationSummary createSummary(
-      NormalizationFunction... functions) {
+      RawFileNormalizationFunction... functions) {
     return createSummary(List.of(functions));
   }
 
   private static @NotNull IntensityNormalizationSummary createSummary(
-      List<NormalizationFunction> functions) {
+      List<RawFileNormalizationFunction> functions) {
     return new IntensityNormalizationSummary(functions);
   }
 
@@ -262,13 +277,12 @@ class NormalizationFunctionsParameterTest {
 
   @Test
   void saveLoadRoundtripKeepsNullAcquisitionTimestampForNonInterpolatedFunctions() {
-    final FactorNormalizationFunction factorFunction = new FactorNormalizationFunction(
-        new RawDataFilePlaceholder("factor_file", tempDir.resolve("factor.mzML").toString(), 11),
-        null, 2d);
-    final StandardCompoundNormalizationFunction standardFunction = new StandardCompoundNormalizationFunction(
-        new RawDataFilePlaceholder("standard_file", tempDir.resolve("standard.mzML").toString(),
-            12), null, StandardUsageType.Nearest, 1d,
-        List.of(new StandardCompoundReferencePoint(100d, 5f, 200d)));
+    final RawFileNormalizationFunction factorFunction = createFactorFunction(
+        createRawFile("factor_file"), null, 2d);
+    final RawFileNormalizationFunction standardFunction = new RawFileNormalizationFunction(
+        createRawFile("standard_file"), null,
+        new StandardCompoundNormalizationFunction(StandardUsageType.Nearest, 1d,
+            List.of(new StandardCompoundReferencePoint(100d, 5f, 200d))));
 
     final NormalizationFunctionsParameter parameter = new NormalizationFunctionsParameter();
     parameter.setValue(createSummary(factorFunction, standardFunction));
@@ -278,16 +292,12 @@ class NormalizationFunctionsParameterTest {
     ParameterUtils.loadParameterFromString(loadedParameter, xml);
 
     final IntensityNormalizationSummary summary = loadedParameter.getValue();
-    final List<NormalizationFunction> loadedFunctions = summary.functions();
+    final List<RawFileNormalizationFunction> loadedFunctions = summary.functions();
     assertEquals(2, loadedFunctions.size());
 
-    final FactorNormalizationFunction loadedFactor = assertInstanceOf(
-        FactorNormalizationFunction.class, loadedFunctions.get(0));
-    assertNull(loadedFactor.acquisitionTimestamp());
-
-    final StandardCompoundNormalizationFunction loadedStandard = assertInstanceOf(
-        StandardCompoundNormalizationFunction.class, loadedFunctions.get(1));
-    assertNull(loadedStandard.acquisitionTimestamp());
+    for (RawFileNormalizationFunction function : loadedFunctions) {
+      assertNull(function.acquisitionTimestamp());
+    }
   }
 
   @Test
@@ -314,24 +324,34 @@ class NormalizationFunctionsParameterTest {
     assertFalse(secondParameter.valueEquals(firstParameter));
   }
 
-  private @NotNull List<NormalizationFunction> createFunctions(final double factorValue) {
-    final FactorNormalizationFunction factorFunction = new FactorNormalizationFunction(
-        new RawDataFilePlaceholder("factor_file", tempDir.resolve("factor.mzML").toString(), 11),
-        LocalDateTime.of(2026, 1, 1, 10, 0), factorValue);
-    final StandardCompoundNormalizationFunction standardFunction = new StandardCompoundNormalizationFunction(
-        new RawDataFilePlaceholder("standard_file", tempDir.resolve("standard.mzML").toString(),
-            12), LocalDateTime.of(2026, 1, 1, 10, 10), StandardUsageType.Nearest, 1d,
-        List.of(new StandardCompoundReferencePoint(100d, 5f, 200d)));
-    final InterpolatedNormalizationFunction interpolatedFunction = new InterpolatedNormalizationFunction(
-        new RawDataFilePlaceholder("target_file", tempDir.resolve("target.mzML").toString(), 13),
-        LocalDateTime.of(2026, 1, 1, 10, 5), factorFunction, 0.25d, standardFunction, 0.75d);
+  private @NotNull List<RawFileNormalizationFunction> createFunctions(final double factorValue) {
+    final RawFileNormalizationFunction factorFunction = createFactorFunction(
+        createRawFile("factor_file"), LocalDateTime.of(2026, 1, 1, 10, 0), factorValue);
+    final RawFileNormalizationFunction standardFunction = new RawFileNormalizationFunction(
+        createRawFile("standard_file"), LocalDateTime.of(2026, 1, 1, 10, 10),
+        new StandardCompoundNormalizationFunction(StandardUsageType.Nearest, 1d,
+            List.of(new StandardCompoundReferencePoint(100d, 5f, 200d))));
+    final RawFileNormalizationFunction interpolatedFunction = new RawFileNormalizationFunction(
+
+        createRawFile("target_file"), LocalDateTime.of(2026, 1, 1, 10, 5),
+        new InterpolatedNormalizationFunction(factorFunction.function(), 0.25d,
+            standardFunction.function(), 0.75d));
     return List.of(factorFunction, standardFunction, interpolatedFunction);
+  }
+
+  static RawFileNormalizationFunction createFactorFunction(@NotNull RawDataFilePlaceholder file,
+      LocalDateTime date, double factor) {
+    return new RawFileNormalizationFunction(file, date, new FactorNormalizationFunction(factor));
+  }
+
+  private @NotNull RawDataFilePlaceholder createRawFile(String name) {
+    return new RawDataFilePlaceholder(name, name + ".mzML", 11);
   }
 
   private @NotNull IntensityNormalizerParameters createIntensityParameters(
       final @NotNull String suffix, final @NotNull AbundanceMeasure abundanceMeasure,
       final @NotNull OriginalFeatureListOption handleOriginal,
-      final @NotNull List<NormalizationFunction> normalizationFunctions) {
+      final @NotNull List<RawFileNormalizationFunction> normalizationFunctions) {
     return IntensityNormalizerParameters.create(
         new FeatureListsSelection(FeatureListsSelectionType.ALL_FEATURELISTS), suffix, null,
         NormalizationType.NoNormalization, null, NormalizationType.TotalRawSignal,

--- a/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/StandardCompoundNormalizationFunctionTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/StandardCompoundNormalizationFunctionTest.java
@@ -25,11 +25,8 @@
 package io.github.mzmine.modules.dataprocessing.norm_intensity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.github.mzmine.datamodel.RawDataFile;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -37,37 +34,29 @@ class StandardCompoundNormalizationFunctionTest {
 
   @Test
   void constructorThrowsIfReferencePointsAreEmpty() {
-    final RawDataFile file = RawDataFile.createDummyFile();
-
     final IllegalStateException exception = assertThrows(IllegalStateException.class,
-        () -> new StandardCompoundNormalizationFunction(file, LocalDateTime.of(2026, 1, 1, 10, 0),
-            StandardUsageType.Nearest, 1.0d, List.of()));
+        () -> new StandardCompoundNormalizationFunction(StandardUsageType.Nearest, 1.0d,
+            List.of()));
 
     assertEquals("No standard reference points available.", exception.getMessage());
   }
 
   @Test
   void nearestUsesClosestReferencePoint() {
-    final RawDataFile file = RawDataFile.createDummyFile();
-    final LocalDateTime timestamp = LocalDateTime.of(2026, 1, 1, 10, 0);
     final StandardCompoundNormalizationFunction function = new StandardCompoundNormalizationFunction(
-        file, timestamp, StandardUsageType.Nearest, 1.0d,
-        List.of(new StandardCompoundReferencePoint(100d, 5f, 200d),
-            new StandardCompoundReferencePoint(150d, 10f, 500d)));
+        StandardUsageType.Nearest, 1.0d, List.of(new StandardCompoundReferencePoint(100d, 5f, 200d),
+        new StandardCompoundReferencePoint(150d, 10f, 500d)));
 
     final double factor = function.getNormalizationFactor(100.1d, 5.1f);
 
     assertEquals(0.005d, factor, 1e-12);
-    assertEquals(timestamp, function.acquisitionTimestamp());
   }
 
   @Test
   void nearestUsesLaterReferencePointOnEqualDistance() {
-    final RawDataFile file = RawDataFile.createDummyFile();
     final StandardCompoundNormalizationFunction function = new StandardCompoundNormalizationFunction(
-        file, LocalDateTime.of(2026, 1, 1, 10, 0), StandardUsageType.Nearest, 1.0d,
-        List.of(new StandardCompoundReferencePoint(100d, 4f, 200d),
-            new StandardCompoundReferencePoint(100d, 6f, 400d)));
+        StandardUsageType.Nearest, 1.0d, List.of(new StandardCompoundReferencePoint(100d, 4f, 200d),
+        new StandardCompoundReferencePoint(100d, 6f, 400d)));
 
     final double factor = function.getNormalizationFactor(100d, 5f);
 
@@ -76,9 +65,8 @@ class StandardCompoundNormalizationFunctionTest {
 
   @Test
   void weightedUsesInverseDistanceAveraging() {
-    final RawDataFile file = RawDataFile.createDummyFile();
     final StandardCompoundNormalizationFunction function = new StandardCompoundNormalizationFunction(
-        file, LocalDateTime.of(2026, 1, 1, 10, 0), StandardUsageType.Weighted, 1.0d,
+        StandardUsageType.Weighted, 1.0d,
         List.of(new StandardCompoundReferencePoint(100d, 4f, 100d),
             new StandardCompoundReferencePoint(100d, 6f, 300d)));
 
@@ -89,9 +77,8 @@ class StandardCompoundNormalizationFunctionTest {
 
   @Test
   void weightedUsesDirectMatchesBeforeDistanceWeights() {
-    final RawDataFile file = RawDataFile.createDummyFile();
     final StandardCompoundNormalizationFunction function = new StandardCompoundNormalizationFunction(
-        file, LocalDateTime.of(2026, 1, 1, 10, 0), StandardUsageType.Weighted, 1.0d,
+        StandardUsageType.Weighted, 1.0d,
         List.of(new StandardCompoundReferencePoint(100d, 5f, 250d),
             new StandardCompoundReferencePoint(100d, 8f, 500d)));
 
@@ -102,10 +89,8 @@ class StandardCompoundNormalizationFunctionTest {
 
   @Test
   void nearestThrowsOnZeroStandardAbundance() {
-    final RawDataFile file = RawDataFile.createDummyFile();
     final StandardCompoundNormalizationFunction function = new StandardCompoundNormalizationFunction(
-        file, LocalDateTime.of(2026, 1, 1, 10, 0), StandardUsageType.Nearest, 1.0d,
-        List.of(new StandardCompoundReferencePoint(100d, 5f, 0d)));
+        StandardUsageType.Nearest, 1.0d, List.of(new StandardCompoundReferencePoint(100d, 5f, 0d)));
 
     final IllegalStateException exception = assertThrows(IllegalStateException.class,
         () -> function.getNormalizationFactor(100d, 5f));
@@ -115,9 +100,8 @@ class StandardCompoundNormalizationFunctionTest {
 
   @Test
   void weightedThrowsOnNonFiniteStandardAbundance() {
-    final RawDataFile file = RawDataFile.createDummyFile();
     final StandardCompoundNormalizationFunction function = new StandardCompoundNormalizationFunction(
-        file, LocalDateTime.of(2026, 1, 1, 10, 0), StandardUsageType.Weighted, 1.0d,
+        StandardUsageType.Weighted, 1.0d,
         List.of(new StandardCompoundReferencePoint(100d, 5f, Double.NaN)));
 
     final IllegalStateException exception = assertThrows(IllegalStateException.class,
@@ -128,32 +112,28 @@ class StandardCompoundNormalizationFunctionTest {
 
   @Test
   void mzVsRtBalanceControlsDistanceWeighting() {
-    final RawDataFile file = RawDataFile.createDummyFile();
     // Point A at mz=100, Point B at mz=110; query at mz=103 is closer to A in m/z.
     // With balance=0, m/z is ignored and both points have equal RT distance,
     // so the later point (B) is picked by the tiebreaking rule.
     final StandardCompoundNormalizationFunction zeroBalance = new StandardCompoundNormalizationFunction(
-        file, LocalDateTime.of(2026, 1, 1, 10, 0), StandardUsageType.Nearest, 0.0d,
-        List.of(new StandardCompoundReferencePoint(100d, 5f, 200d),
-            new StandardCompoundReferencePoint(110d, 5f, 400d)));
+        StandardUsageType.Nearest, 0.0d, List.of(new StandardCompoundReferencePoint(100d, 5f, 200d),
+        new StandardCompoundReferencePoint(110d, 5f, 400d)));
 
     assertEquals(1d / 400d, zeroBalance.getNormalizationFactor(103d, 5f), 1e-12);
 
     // With balance=1.0, mz distance is included: A is nearest (dist 3 vs 7).
     final StandardCompoundNormalizationFunction unitBalance = new StandardCompoundNormalizationFunction(
-        file, LocalDateTime.of(2026, 1, 1, 10, 0), StandardUsageType.Nearest, 1.0d,
-        List.of(new StandardCompoundReferencePoint(100d, 5f, 200d),
-            new StandardCompoundReferencePoint(110d, 5f, 400d)));
+        StandardUsageType.Nearest, 1.0d, List.of(new StandardCompoundReferencePoint(100d, 5f, 200d),
+        new StandardCompoundReferencePoint(110d, 5f, 400d)));
 
     assertEquals(1d / 200d, unitBalance.getNormalizationFactor(103d, 5f), 1e-12);
   }
 
   @Test
   void weightedAveragesMultipleDirectMatches() {
-    final RawDataFile file = RawDataFile.createDummyFile();
     // Two points at identical mz and RT — both are direct matches for the query.
     final StandardCompoundNormalizationFunction function = new StandardCompoundNormalizationFunction(
-        file, LocalDateTime.of(2026, 1, 1, 10, 0), StandardUsageType.Weighted, 1.0d,
+        StandardUsageType.Weighted, 1.0d,
         List.of(new StandardCompoundReferencePoint(100d, 5f, 200d),
             new StandardCompoundReferencePoint(100d, 5f, 400d)));
 
@@ -163,12 +143,10 @@ class StandardCompoundNormalizationFunctionTest {
 
   @Test
   void constructorAcceptsNullAcquisitionTimestamp() {
-    final RawDataFile file = RawDataFile.createDummyFile();
     final StandardCompoundNormalizationFunction function = new StandardCompoundNormalizationFunction(
-        file, null, StandardUsageType.Nearest, 1.0d,
+        StandardUsageType.Nearest, 1.0d,
         List.of(new StandardCompoundReferencePoint(100d, 5f, 200d)));
 
-    assertNull(function.acquisitionTimestamp());
     assertEquals(0.005d, function.getNormalizationFactor(100d, 5f), 1e-12);
   }
 }

--- a/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/StandardCompoundNormalizationTypeModuleTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/modules/dataprocessing/norm_intensity/StandardCompoundNormalizationTypeModuleTest.java
@@ -205,10 +205,10 @@ class StandardCompoundNormalizationTypeModuleTest {
         List.of(prevFile, targetFile, nextFile));
 
     final StandardCompoundNormalizationFunction prevFunction = new StandardCompoundNormalizationFunction(
-        prevFile, prevFile.getStartTimeStamp(), StandardUsageType.Nearest, 1.0d,
+        StandardUsageType.Nearest, 1.0d,
         List.of(new StandardCompoundReferencePoint(100d, 5f, 400d)));
     final StandardCompoundNormalizationFunction nextFunction = new StandardCompoundNormalizationFunction(
-        nextFile, nextFile.getStartTimeStamp(), StandardUsageType.Nearest, 1.0d,
+        StandardUsageType.Nearest, 1.0d,
         List.of(new StandardCompoundReferencePoint(100d, 5f, 200d)));
 
     final IntensityNormalizationSearchableSummary summary = new IntensityNormalizationSearchableSummary(
@@ -216,9 +216,14 @@ class StandardCompoundNormalizationTypeModuleTest {
     summary.addMergeFunction(prevFile, prevFunction);
     summary.addMergeFunction(nextFile, nextFunction);
 
+    // internally we never use summary.functions for interpolation because
+    // interpolation should be based on a single steps functions not on the merged composite function
+    Map<RawDataFile, NormalizationFunction> functions = Map.of(prevFile, prevFunction, nextFile,
+        nextFunction);
+
     module.interpolateAllFunctionsToSummary(summary, featureList,
         new SamplesBatch(featureList.getRawDataFiles()), new MetadataTable(false),
-        summary.functions(), createMainParameters(AbundanceMeasure.Height),
+        functions, createMainParameters(AbundanceMeasure.Height),
         createModuleParametersWithoutStandards(StandardUsageType.Nearest, false));
 
     var result = summary.get(targetFile);


### PR DESCRIPTION
- makes NormalizationFunction independent from RawDataFilePlaceholder by moving the raw data file and acquisition date to an outer record
- easier definition of functions, no need to handle load save of raw data file and date
- removes the withRawDataFile function and easier to reuse function for other raw data files. Like when interpolation is only based on one reference sample because the target sample was acquired after all references. Another case is inter batch correction where the whole batch uses the same FactorNormalizationFunction
- testing of NormalizationFunction without raw data files is also easier if the data file is not needed